### PR TITLE
Link do grupo atualizado e RegEx modificada

### DIFF
--- a/commands/link.js
+++ b/commands/link.js
@@ -1,13 +1,13 @@
 'use strict'
 
 const fn = async ({ msg, match, responseTypes, accessors }) => {
-  const chatLink = "https://t.me/garoactf"
+  const chatLink = "https://t.me/ctfsp"
   return [ {
     type: responseTypes.TEXT,
     content: `Link do grupo: ${chatLink}`
   } ]
 }
 
-fn.regex = /\/link/
+fn.regex = /^\/link/
 
 module.exports = fn


### PR DESCRIPTION
- Link do grupo alterado para "https://t.me/ctfsp"
- RegEx alterada para que o comando seja executado somente se chamado no início da mensagem, para evitar falsos positivos, como "https://exemplo.com/link/?id=xxx", por exemplo