### PR TITLE
Corrige RegEx

### DIFF
--- a/commands/events.js
+++ b/commands/events.js
@@ -32,4 +32,4 @@ const fn = async ({ repositories, chat, responseTypes }) => {
 }
 
 module.exports = fn
-module.exports.regex = /\/events/
+module.exports.regex = /^\/events/


### PR DESCRIPTION
RegEx alterada para que o comando seja executado somente se chamado no início da mensagem, para evitar falsos positivos.